### PR TITLE
• Replace links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ description: Лимб. Все дороги ведут отсюда.
 ## Библиотеки для работы с SD.C API
 
 1. [sdc-api](https://github.com/MegaVasiliy007/sdc-api) \| NodeJS _\(By_ [_SDC_](https://sdc.su/)_\)_
-1. [sdc-type](https://github.com/vladciphersky/sdc-type) \| TypeScript _\(By_ [_SDC_](https://sdc.su/)_\)_
+1. [sdc-type](https://github.com/sqdshcom/sdc-type) \| TypeScript _\(By_ [_Sqdsh.Community_](https://github.com/sqdshcom/)_\)_
 2. [sdc-api](https://pypi.org/project/sdc-api/) \| Python _\(By Pineapple\_Cookie \(美波🌊 fan\)\#0373\)_
 
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ description: Лимб. Все дороги ведут отсюда.
 
 ## Библиотеки для работы с SD.C API
 
-1. [sdc-api](https://npmjs.com/package/sdc-api) \| Node JS _\(By_ [_SDC_](https://sdc.su/)_\)_
+1. [sdc-api](https://github.com/MegaVasiliy007/sdc-api) \| NodeJS _\(By_ [_SDC_](https://sdc.su/)_\)_
+1. [sdc-type](https://github.com/vladciphersky/sdc-type) \| TypeScript _\(By_ [_SDC_](https://sdc.su/)_\)_
 2. [sdc-api](https://pypi.org/project/sdc-api/) \| Python _\(By Pineapple\_Cookie \(美波🌊 fan\)\#0373\)_
 
 


### PR DESCRIPTION
• Заменена ссылка на **[sdc-api](https://github.com/MegaVasiliy007/sdc-api)**
• Добавлено упоминание о версии на TypeScript (**[sdc-type](https://github.com/vladciphersky/sdc-type)**)